### PR TITLE
Option to print text and plaintext descriptions

### DIFF
--- a/apis.py
+++ b/apis.py
@@ -46,6 +46,21 @@ def load_boilerplate(config):
         boilerplate = string.Template(instructions + f.read())
     return boilerplate.substitute(phone=phone)
 
+def load_text_title(topic):
+    with open("meetups/title/%s.md" % topic) as f:
+        topic_title = f.read()
+    return topic_title
+
+def load_text_and_plaintext_body(topic):
+    with open("meetups/body/%s.md" % topic) as f:
+        topic_text = f.read()
+    try:
+        with open("meetups/plainbody/%s.md" % topic) as f:
+            topic_plaintext = f.read()
+    except IOError:
+        topic_plaintext = topic_text
+    return (topic_text, topic_plaintext)
+
 def gen_body(topic, config):
     boilerplate = load_boilerplate(config)
     with open("meetups/body/%s.md" % topic) as f:
@@ -326,16 +341,8 @@ def fb_post_meetup(topic, config, public=False):
 
 def email_pieces(topic, config):
     boilerplate = load_boilerplate(config)
-    with open("meetups/title/%s.md" % topic) as f:
-        topic_title = f.read()
-    with open("meetups/body/%s.md" % topic) as f:
-        topic_text = f.read()
-        topic_plaintext = topic_text
-    try:
-        with open("meetups/plainbody/%s.md" % topic) as f:
-            topic_plaintext = f.read()
-    except IOError:
-        topic_plaintext = topic_text
+    topic_title = load_text_title(topic)
+    topic_text, topic_plaintext = load_text_and_plaintext_body(topic)
     date = next_meetup_date(config)
     location = config.get("location")
     when_str = date.strftime("%d %B %Y, 6:15 PM")

--- a/apis.py
+++ b/apis.py
@@ -89,8 +89,8 @@ def gen_time(hour24, minute):
     else:
         h = hour24
         half = "AM"
-    t = "%s:%s $s" % (h, minute, half)
-    return date.strftime("%d %B %Y, "+t)
+    t = "%s:%s %s" % (h, minute, half)
+    return datetime.strftime("%d %B %Y, "+t)
 
 def message_plaintext(time_str, loc_str, topic_text, boilerplate):
     return """WHEN: %s
@@ -110,19 +110,20 @@ def message_markdown(time_str, loc_str, topic_text, boilerplate):
     """ % (time_str, loc_str, topic_text, boilerplate)
 
 def message_html(time_str, loc_str, topic_text, boilerplate):
-    return markdown.markdown(full_markdown(time_str, loc_str, topic_text, boilerplate))
+    return markdown.markdown(message_markdown(time_str, loc_str, topic_text, boilerplate))
 
-def plaintext_with_title(topic, meetup_name, date_str, time_str, loc_str, topic_text, boilerplate):
+def plaintext_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate):
+    topic_text, _ = load_text_and_plaintext_body(topic)
     return "%s\n%s" % (gen_title_with_date(topic, meetup_name, date_str),
             message_plaintext(time_str, loc_str, topic_text, boilerplate))
 
-def markdown_with_title(topic, meetup_name, date_str, time_str, loc_str, topic_text, boilerplate):
+def markdown_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate):
+    _, topic_text = load_text_and_plaintext_body(topic)
     return "__%s__\n\n%s" % (gen_title_with_date(topic, meetup_name, date_str),
             message_markdown(time_str, loc_str, topic_text, boilerplate))
 
-def html_with_title(topic, meetup_name, date_str, time_str, loc_str, topic_text, boilerplate):
-    return markdown.markdown(markdown_with_title(gen_title_with_date(topic, meetup_name, date_str),
-        message_markdown(time_str, loc_str, topic_text, boilerplate)))
+def html_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate):
+    return markdown.markdown(markdown_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate))
 
 
 
@@ -498,9 +499,24 @@ def update_ssc_meetup(title, config, public, lw_url=None):
 
 
 def print_text_meetup(topic, config):
+    boilerplate = load_boilerplate(config)
+    topic_title = load_text_title(topic)
+    date_str = next_meetup_date(config)
+    location = config.get("location")
+    time_str = gen_time(18, 15) # make this config later
+    html_email = message_html(when_str, location.get("str"), topic_text, boilerplate)
+    markdown_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate)
     print("plain text not printed")
 
 def print_plaintext_meetup(topic, config):
+    boilerplate = load_boilerplate(config)
+    topic_title = load_text_title(topic)
+    _, topic_plaintext = load_text_and_plaintext_body(topic)
+    date_str = next_meetup_date(config)
+    location = config.get("location")
+    time_str = gen_time(18, 15) # make this config later
+    plain_email = message_plaintext(when_str, location.get("str"), topic_plaintext, boilerplate)
+    plaintext_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate)
     print("markdow-formatted text not printed")
 
 

--- a/apis.py
+++ b/apis.py
@@ -61,6 +61,7 @@ def load_text_and_plaintext_body(topic):
         topic_plaintext = topic_text
     return (topic_text, topic_plaintext)
 
+# MARK to MARKDOWN
 def gen_body(topic, config):
     boilerplate = load_boilerplate(config)
     topic_text, _ = load_text_and_plaintext_body(topic)
@@ -354,6 +355,7 @@ def email_pieces(topic, config):
     email_title = _email_title(topic_title, config, date)
     return (email_title, plain_email, html_email)
 
+# MARK to MARKDOWN
 def _email_plaintext(time_str, loc_str, topic_text, boilerplate):
     return """WHEN: %s
 WHERE: %s
@@ -468,6 +470,15 @@ def update_ssc_meetup(title, config, public, lw_url=None):
 
 
 
+def print_text_meetup(topic, config):
+    print("plain text not printed")
+
+def print_plaintext_meetup(topic, config):
+    print("markdow-formatted text not printed")
+
+
+
+
 def print_command(command, **kwargs):
     print(" ".join(command))
     p = Popen(command, stdout=PIPE, stderr=PIPE, **kwargs)
@@ -559,9 +570,9 @@ def post(config, topic, host, public=True, skip=None, lw_url=None):
         send_meetup_email(topic, config, gmail_username, toaddr)
         print("Email Sent")
     if "plaintext" not in skip:
-        print("plain text not printed")
+        print_text_meetup(topic, config)
     if "markdown" not in skip:
-        print("markdow-formatted text not printed")
+        print_plaintext_meetup(topic, config)
 
 if __name__ == "__main__":
     cfg = config()

--- a/apis.py
+++ b/apis.py
@@ -427,8 +427,10 @@ def send_meetup_email(topic, config, gmail_username, toaddr):
 
 
 
-def print_text_meetup(topic, config):
-    boilerplate = load_boilerplate(config)
+def print_text_meetup(topic, config, use_boilerplate):
+    boilerplate = ""
+    if use_boilerplate:
+        boilerplate = load_boilerplate(config)
     topic_title = load_text_title(topic)
     meetup_name = config.get("meetup_name")
     date_str = next_meetup_date(config)
@@ -437,8 +439,10 @@ def print_text_meetup(topic, config):
     time_str = gen_time(18, 15) # make this config later
     print(markdown_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate))
 
-def print_plaintext_meetup(topic, config):
-    boilerplate = load_boilerplate(config)
+def print_plaintext_meetup(topic, config, use_boilerplate):
+    boilerplate = ""
+    if use_boilerplate:
+        boilerplate = load_boilerplate(config)
     topic_title = load_text_title(topic)
     _, topic_plaintext = load_text_and_plaintext_body(topic)
     meetup_name = config.get("meetup_name")
@@ -538,10 +542,22 @@ def post(config, topic, host, public=True, skip=None, lw_url=None):
             toaddr = "%s@gmail.com" % gmail_username
         send_meetup_email(topic, config, gmail_username, toaddr)
         print("Email Sent")
-    if "plaintext" not in skip:
-        print_text_meetup(topic, config)
-    if "markdown" not in skip:
-        print_plaintext_meetup(topic, config)
+    print_plaintext = "plaintext" not in skip
+    print_formatted_text = "markdown" not in skip
+    if print_plaintext or print_formatted_text:
+        boil_input = input("include boilerplate? (y/N) ")
+        coerced_boil = boil_input.strip().lower()
+        if coerced_boil == "y" or coerced_boil == "yes":
+            boil = True
+        elif coerced_boil == "n" or coerced_boil == "no":
+            boil = False
+        else:
+            print("Didn't understand response, defaulting to no boilerplate")
+            boil = False
+    if print_plaintext:
+        print_text_meetup(topic, config, boil)
+    if print_formatted_text:
+        print_plaintext_meetup(topic, config, boil)
 
 if __name__ == "__main__":
     cfg = config()

--- a/apis.py
+++ b/apis.py
@@ -430,23 +430,23 @@ def send_meetup_email(topic, config, gmail_username, toaddr):
 def print_text_meetup(topic, config):
     boilerplate = load_boilerplate(config)
     topic_title = load_text_title(topic)
+    meetup_name = config.get("meetup_name")
     date_str = next_meetup_date(config)
     location = config.get("location")
+    loc_str = location.get("str")
     time_str = gen_time(18, 15) # make this config later
-    html_email = message_html(when_str, location.get("str"), topic_text, boilerplate)
-    markdown_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate)
-    print("plain text not printed")
+    print(markdown_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate))
 
 def print_plaintext_meetup(topic, config):
     boilerplate = load_boilerplate(config)
     topic_title = load_text_title(topic)
     _, topic_plaintext = load_text_and_plaintext_body(topic)
+    meetup_name = config.get("meetup_name")
     date_str = next_meetup_date(config)
     location = config.get("location")
+    loc_str = location.get("str")
     time_str = gen_time(18, 15) # make this config later
-    plain_email = message_plaintext(when_str, location.get("str"), topic_plaintext, boilerplate)
-    plaintext_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate)
-    print("markdow-formatted text not printed")
+    print(plaintext_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate))
 
 
 

--- a/apis.py
+++ b/apis.py
@@ -548,6 +548,10 @@ def post(config, topic, host, public=True, skip=None, lw_url=None):
             toaddr = "%s@gmail.com" % gmail_username
         send_meetup_email(topic, config, gmail_username, toaddr)
         print("Email Sent")
+    if "plaintext" not in skip:
+        print("plain text not printed")
+    if "markdown" not in skip:
+        print("markdow-formatted text not printed")
 
 if __name__ == "__main__":
     cfg = config()

--- a/apis.py
+++ b/apis.py
@@ -112,12 +112,12 @@ def message_html(time_str, loc_str, topic_text, boilerplate):
     return markdown.markdown(message_markdown(time_str, loc_str, topic_text, boilerplate))
 
 def plaintext_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate):
-    topic_text, _ = load_text_and_plaintext_body(topic)
+    _, topic_plaintext = load_text_and_plaintext_body(topic)
     return "%s\n%s" % (gen_title_with_date(topic, meetup_name, date_str),
-            message_plaintext(time_str, loc_str, topic_text, boilerplate))
+            message_plaintext(time_str, loc_str, topic_plaintext, boilerplate))
 
 def markdown_with_title(topic, meetup_name, date_str, time_str, loc_str, boilerplate):
-    _, topic_text = load_text_and_plaintext_body(topic)
+    topic_text, _ = load_text_and_plaintext_body(topic)
     return "__%s__\n\n%s" % (gen_title_with_date(topic, meetup_name, date_str),
             message_markdown(time_str, loc_str, topic_text, boilerplate))
 
@@ -444,7 +444,6 @@ def print_plaintext_meetup(topic, config, use_boilerplate):
     if use_boilerplate:
         boilerplate = load_boilerplate(config)
     topic_title = load_text_title(topic)
-    _, topic_plaintext = load_text_and_plaintext_body(topic)
     meetup_name = config.get("meetup_name")
     date_str = next_meetup_date(config)
     location = config.get("location")

--- a/apis.py
+++ b/apis.py
@@ -89,8 +89,7 @@ def gen_time(hour24, minute):
     else:
         h = hour24
         half = "AM"
-    t = "%s:%s %s" % (h, minute, half)
-    return datetime.strftime("%d %B %Y, "+t)
+    return "%s:%s %s" % (h, minute, half)
 
 def message_plaintext(time_str, loc_str, topic_text, boilerplate):
     return """WHEN: %s

--- a/apis.py
+++ b/apis.py
@@ -79,6 +79,18 @@ def gen_title(topic, meetup_name):
 def gen_title_with_date(topic, meetup_name, date_str):
     return "%s: %s: %s" % (meetup_name, date_str, topic)
 
+def gen_time(hour24, minute):
+    if hour24 > 12:
+        h = hour24-12
+        half = "PM"
+    elif hour24 = 0:
+        h = 12
+        half = "AM"
+    else:
+        h = hour24
+        half = "AM"
+    t = "%s:%s $s" % (h, minute, half)
+    return date.strftime("%d %B %Y, "+t)
 
 
 
@@ -349,7 +361,7 @@ def email_pieces(topic, config):
     topic_text, topic_plaintext = load_text_and_plaintext_body(topic)
     date = next_meetup_date(config)
     location = config.get("location")
-    when_str = date.strftime("%d %B %Y, 6:15 PM")
+    when_str = gen_time(18, 15) # make this config later
     plain_email = _email_plaintext(when_str, location.get("str"), topic_plaintext, boilerplate)
     html_email = _email_html(when_str, location.get("str"), topic_text, boilerplate)
     email_title = _email_title(topic_title, config, date)

--- a/apis.py
+++ b/apis.py
@@ -83,7 +83,7 @@ def gen_time(hour24, minute):
     if hour24 > 12:
         h = hour24-12
         half = "PM"
-    elif hour24 = 0:
+    elif hour24 == 0:
         h = 12
         half = "AM"
     else:

--- a/apis.py
+++ b/apis.py
@@ -77,7 +77,8 @@ def gen_title(topic, meetup_name):
     return "%s: %s" % (meetup_name, topic_title)
 
 def gen_title_with_date(topic, meetup_name, date_str):
-    return "%s: %s: %s" % (meetup_name, date_str, topic)
+    topic_title = load_text_title(topic).strip()
+    return "%s: %s: %s" % (meetup_name, date_str, topic_title)
 
 def gen_time(hour24, minute):
     if hour24 > 12:
@@ -548,7 +549,7 @@ def post(config, topic, host, public=True, skip=None, lw_url=None):
         coerced_boil = boil_input.strip().lower()
         if coerced_boil == "y" or coerced_boil == "yes":
             boil = True
-        elif coerced_boil == "n" or coerced_boil == "no":
+        elif coerced_boil == "n" or coerced_boil == "no" or coerced_boil == "":
             boil = False
         else:
             print("Didn't understand response, defaulting to no boilerplate")

--- a/apis.py
+++ b/apis.py
@@ -63,13 +63,16 @@ def load_text_and_plaintext_body(topic):
 
 def gen_body(topic, config):
     boilerplate = load_boilerplate(config)
-    with open("meetups/body/%s.md" % topic) as f:
-        topic_text = f.read()
+    topic_text, _ = load_text_and_plaintext_body(topic)
     return "%s\n%s" % (topic_text, boilerplate)
 
+def gen_plaintext_body(topic, config):
+    boilerplate = load_boilerplate(config)
+    _, topic_plaintext = load_text_and_plaintext_body(topic)
+    return "%s\n%s" % (topic_plaintext, boilerplate)
+
 def gen_title(topic, meetup_name):
-    with open("meetups/title/%s.md" % topic) as f:
-        topic_title = f.read().strip()
+    topic_title = load_text_title(topic).strip()
     return "%s: %s" % (meetup_name, topic_title)
 
 def gen_title_with_date(topic, meetup_name, date_str):

--- a/apis.py
+++ b/apis.py
@@ -92,6 +92,39 @@ def gen_time(hour24, minute):
     t = "%s:%s $s" % (h, minute, half)
     return date.strftime("%d %B %Y, "+t)
 
+def message_plaintext(time_str, loc_str, topic_text, boilerplate):
+    return """WHEN: %s
+WHERE: %s
+
+%s
+%s
+    """ % (time_str, loc_str, topic_text, boilerplate)
+
+def message_markdown(time_str, loc_str, topic_text, boilerplate):
+    return """**WHEN:** %s
+
+**WHERE:** %s
+
+%s
+%s
+    """ % (time_str, loc_str, topic_text, boilerplate)
+
+def message_html(time_str, loc_str, topic_text, boilerplate):
+    return markdown.markdown(full_markdown(time_str, loc_str, topic_text, boilerplate))
+
+def plaintext_with_title(topic, meetup_name, date_str, time_str, loc_str, topic_text, boilerplate):
+    return "%s\n%s" % (gen_title_with_date(topic, meetup_name, date_str),
+            message_plaintext(time_str, loc_str, topic_text, boilerplate))
+
+def markdown_with_title(topic, meetup_name, date_str, time_str, loc_str, topic_text, boilerplate):
+    return "__%s__\n\n%s" % (gen_title_with_date(topic, meetup_name, date_str),
+            message_markdown(time_str, loc_str, topic_text, boilerplate))
+
+def html_with_title(topic, meetup_name, date_str, time_str, loc_str, topic_text, boilerplate):
+    return markdown.markdown(markdown_with_title(gen_title_with_date(topic, meetup_name, date_str),
+        message_markdown(time_str, loc_str, topic_text, boilerplate)))
+
+
 
 
 def lw2_title(topic, config):
@@ -362,28 +395,10 @@ def email_pieces(topic, config):
     date = next_meetup_date(config)
     location = config.get("location")
     when_str = gen_time(18, 15) # make this config later
-    plain_email = _email_plaintext(when_str, location.get("str"), topic_plaintext, boilerplate)
-    html_email = _email_html(when_str, location.get("str"), topic_text, boilerplate)
+    plain_email = message_plaintext(when_str, location.get("str"), topic_plaintext, boilerplate)
+    html_email = message_html(when_str, location.get("str"), topic_text, boilerplate)
     email_title = _email_title(topic_title, config, date)
     return (email_title, plain_email, html_email)
-
-# MARK to MARKDOWN
-def _email_plaintext(time_str, loc_str, topic_text, boilerplate):
-    return """WHEN: %s
-WHERE: %s
-
-%s
-%s
-    """ % (time_str, loc_str, topic_text, boilerplate)
-
-def _email_html(time_str, loc_str, topic_text, boilerplate):
-    return markdown.markdown("""**WHEN:** %s
-
-**WHERE:** %s
-
-%s
-%s
-    """ % (time_str, loc_str, topic_text, boilerplate))
 
 def _email_title(topic, config, date_obj):
     return gen_title_with_date(topic, config.get("meetup_name"), date_obj.isoformat())


### PR DESCRIPTION
This cuts down the work to submit to an unsupported platform to copy-and-paste

Supports markdown-formatted text and plaintext, supports with and without boilerplate